### PR TITLE
PDE migrate to Trixie

### DIFF
--- a/sonic-pde-tests/sonic_pde_saiut/Makefile
+++ b/sonic-pde-tests/sonic_pde_saiut/Makefile
@@ -1,8 +1,12 @@
 SAI_INC := /usr/include/sai
 SAI_LIB := /usr/lib
 
+
+PYTHON_VERSION := $(shell python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')
+PYTHON_INC     := /usr/include/python$(PYTHON_VERSION)
+
 CC      := gcc
-CFLAGS  := -fPIC -I/usr/include/python3.11 -I$(SAI_INC) -I$(SAI_INC)/experimental
+CFLAGS  := -fPIC -I$(PYTHON_INC) -I$(SAI_INC) -I$(SAI_INC)/experimental
 
 LDFLAGS := -L$(SAI_LIB) -lsai
 
@@ -11,17 +15,22 @@ all: _saiut.so
 setup:
 	rm -rf .inc
 	mkdir -p .inc
-	ln -s $(SAI_INC)/saitypes.h .inc/
-	ln -s $(SAI_INC)/saistatus.h .inc/
-	ln -s $(SAI_INC)/saiport.h .inc/
+	ln -sf $(SAI_INC)/saitypes.h .inc/
+	ln -sf $(SAI_INC)/saistatus.h .inc/
+	ln -sf $(SAI_INC)/saiport.h .inc/
 
 saiut_wrap.c: setup saiut.i
 	swig -python saiut.i
 
 saiut_wrap.o: saiut_wrap.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+saiut.o: saiut.c
+	$(CC) $(CFLAGS) -c $< -o $@
 
 _saiut.so: saiut.o saiut_wrap.o
-	gcc -shared $^ $(LDFLAGS) -o $@
+	$(CC) -shared $^ $(LDFLAGS) -o $@
 
 clean:
 	rm -rf *.so *.o *_wrap.c saiut.py saiut.pyc .inc/
+

--- a/sonic-pde-tests/sonic_pde_saiut/Makefile
+++ b/sonic-pde-tests/sonic_pde_saiut/Makefile
@@ -2,11 +2,9 @@ SAI_INC := /usr/include/sai
 SAI_LIB := /usr/lib
 
 
-PYTHON_VERSION := $(shell python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')
-PYTHON_INC     := /usr/include/python$(PYTHON_VERSION)
-
+PYTHON_CFLAGS := $(shell python3-config --includes)
 CC      := gcc
-CFLAGS  := -fPIC -I$(PYTHON_INC) -I$(SAI_INC) -I$(SAI_INC)/experimental
+CFLAGS  := -fPIC $(PYTHON_CFLAGS) -I$(SAI_INC) -I$(SAI_INC)/experimental
 
 LDFLAGS := -L$(SAI_LIB) -lsai
 


### PR DESCRIPTION
Why I did it
Upgrade  PDE  to Trixie

Work item tracking
Microsoft ADO (number only):
How I did it
Update the relevant Makefile and Dockerfile to have use Trixie version of debian

How to verify it
Login to docker to see the version of debian updated to Trixie in /etc/os-release output

Which release branch to backport (provide reason below if selected)
 202305
 202311
 202405
 202411
 202505
 202511
Tested branch (Please provide the tested image version)


Description for the changelog
Link to config_db schema for YANG module changes
A picture of a cute animal (not mandatory but encouraged)